### PR TITLE
List clusters based on org

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,49 +200,69 @@ GET `/v1/docdb/{account}/{name}`
 #### Example get response
 ```json
 {
-    "AssociatedRoles": null,
-    "AvailabilityZones": [
-        "us-east-1f",
-        "us-east-1d",
-        "us-east-1a"
-    ],
-    "BackupRetentionPeriod": 1,
-    "ClusterCreateTime": "2021-08-05T13:23:03.003Z",
-    "DBClusterArn": "arn:aws:rds:us-east-1:123456789012:cluster:mydocdb",
-    "DBClusterIdentifier": "mydocdb",
-    "DBClusterMembers": [
+    "Cluster": {
+        "AssociatedRoles": null,
+        "AvailabilityZones": [
+            "us-east-1f",
+            "us-east-1d",
+            "us-east-1a"
+        ],
+        "BackupRetentionPeriod": 1,
+        "ClusterCreateTime": "2021-08-05T13:23:03.003Z",
+        "DBClusterArn": "arn:aws:rds:us-east-1:123456789012:cluster:mydocdb",
+        "DBClusterIdentifier": "mydocdb",
+        "DBClusterMembers": [
+            {
+                "DBClusterParameterGroupStatus": "in-sync",
+                "DBInstanceIdentifier": "mydocdb-1",
+                "IsClusterWriter": true,
+                "PromotionTier": 1
+            }
+        ],
+        "DBClusterParameterGroup": "default.docdb4.0",
+        "DBSubnetGroup": "spinup-example-docdb-subnetgroup",
+        "DbClusterResourceId": "cluster-IBME365R7OUKGHZYEOHDJWLBSQ",
+        "DeletionProtection": false,
+        "EarliestRestorableTime": "2021-08-05T13:23:43.551Z",
+        "EnabledCloudwatchLogsExports": null,
+        "Endpoint": "mydocdb.cluster-z0ukc6s0rmbg.us-east-1.docdb.amazonaws.com",
+        "Engine": "docdb",
+        "EngineVersion": "4.0.0",
+        "HostedZoneId": "ZZXXYY5TT8WVW",
+        "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/11aa0000-8fcb-4e65-abb4-eed7f4a012f7",
+        "LatestRestorableTime": "2021-08-05T13:23:43.551Z",
+        "MasterUsername": "dadmin",
+        "MultiAZ": false,
+        "PercentProgress": null,
+        "Port": 27017,
+        "PreferredBackupWindow": "08:41-09:11",
+        "PreferredMaintenanceWindow": "mon:10:08-mon:10:38",
+        "ReaderEndpoint": "mydocdb.cluster-ro-z0ukc6s0rmbg.us-east-1.docdb.amazonaws.com",
+        "Status": "available",
+        "StorageEncrypted": true,
+        "VpcSecurityGroups": [
+            {
+                "Status": "active",
+                "VpcSecurityGroupId": "sg-0abcdef1234567890"
+            }
+        ]
+    },
+    "Tags": [
         {
-            "DBClusterParameterGroupStatus": "in-sync",
-            "DBInstanceIdentifier": "mydocdb-1",
-            "IsClusterWriter": true,
-            "PromotionTier": 1
-        }
-    ],
-    "DBClusterParameterGroup": "default.docdb4.0",
-    "DBSubnetGroup": "spinup-example-docdb-subnetgroup",
-    "DbClusterResourceId": "cluster-IBME365R7OUKGHZYEOHDJWLBSQ",
-    "DeletionProtection": false,
-    "EarliestRestorableTime": "2021-08-05T13:23:43.551Z",
-    "EnabledCloudwatchLogsExports": null,
-    "Endpoint": "mydocdb.cluster-z0ukc6s0rmbg.us-east-1.docdb.amazonaws.com",
-    "Engine": "docdb",
-    "EngineVersion": "4.0.0",
-    "HostedZoneId": "ZZXXYY5TT8WVW",
-    "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/11aa0000-8fcb-4e65-abb4-eed7f4a012f7",
-    "LatestRestorableTime": "2021-08-05T13:23:43.551Z",
-    "MasterUsername": "dadmin",
-    "MultiAZ": false,
-    "PercentProgress": null,
-    "Port": 27017,
-    "PreferredBackupWindow": "08:41-09:11",
-    "PreferredMaintenanceWindow": "mon:10:08-mon:10:38",
-    "ReaderEndpoint": "mydocdb.cluster-ro-z0ukc6s0rmbg.us-east-1.docdb.amazonaws.com",
-    "Status": "available",
-    "StorageEncrypted": true,
-    "VpcSecurityGroups": [
+            "Key": "spinup:flavor",
+            "Value": "docdb"
+        },
         {
-            "Status": "active",
-            "VpcSecurityGroupId": "sg-0abcdef1234567890"
+            "Key": "CreatedBy",
+            "Value": "me"
+        },
+        {
+            "Key": "spinup:org",
+            "Value": "localdev"
+        },
+        {
+            "Key": "spinup:type",
+            "Value": "database"
         }
     ]
 }

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -69,7 +69,7 @@ func handleError(w http.ResponseWriter, err error) {
 		default:
 			w.WriteHeader(http.StatusInternalServerError)
 		}
-		w.Write([]byte(aerr.Message))
+		w.Write([]byte(err.Error()))
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))

--- a/api/handlers_docdb.go
+++ b/api/handlers_docdb.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	db "github.com/YaleSpinup/docdb-api/docdb"
+	"github.com/YaleSpinup/docdb-api/resourcegroupstaggingapi"
 )
 
 // DocumentDBCreateHandler creates a documentDB cluster and instance(s)
@@ -44,6 +45,7 @@ func (s *server) DocumentDBCreateHandler(w http.ResponseWriter, r *http.Request)
 
 	orch := newDocDBOrchestrator(
 		db.New(db.WithSession(sess.Session)),
+		nil,
 		s.org,
 	)
 
@@ -96,6 +98,7 @@ func (s *server) DocumentDBDeleteHandler(w http.ResponseWriter, r *http.Request)
 
 	orch := newDocDBOrchestrator(
 		db.New(db.WithSession(sess.Session)),
+		nil,
 		s.org,
 	)
 
@@ -122,6 +125,7 @@ func (s *server) DocumentDBListHandler(w http.ResponseWriter, r *http.Request) {
 		role,
 		"",
 		"arn:aws:iam::aws:policy/AmazonDocDBReadOnlyAccess",
+		"arn:aws:iam::aws:policy/ResourceGroupsandTagEditorReadOnlyAccess",
 	)
 	if err != nil {
 		msg := fmt.Sprintf("failed to assume role in account: %s", account)
@@ -131,6 +135,7 @@ func (s *server) DocumentDBListHandler(w http.ResponseWriter, r *http.Request) {
 
 	orch := newDocDBOrchestrator(
 		db.New(db.WithSession(sess.Session)),
+		resourcegroupstaggingapi.New(resourcegroupstaggingapi.WithSession(sess.Session)),
 		s.org,
 	)
 
@@ -146,6 +151,7 @@ func (s *server) DocumentDBListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("X-Items", strconv.Itoa(len(resp)))
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	w.Write(j)
@@ -175,6 +181,7 @@ func (s *server) DocumentDBGetHandler(w http.ResponseWriter, r *http.Request) {
 
 	orch := newDocDBOrchestrator(
 		db.New(db.WithSession(sess.Session)),
+		nil,
 		s.org,
 	)
 

--- a/api/orchestrators.go
+++ b/api/orchestrators.go
@@ -2,16 +2,19 @@ package api
 
 import (
 	"github.com/YaleSpinup/docdb-api/docdb"
+	"github.com/YaleSpinup/docdb-api/resourcegroupstaggingapi"
 )
 
 type docDBOrchestrator struct {
-	client docdb.DocDB
-	org    string
+	client   docdb.DocDB
+	rgClient *resourcegroupstaggingapi.ResourceGroupsTaggingAPI
+	org      string
 }
 
-func newDocDBOrchestrator(client docdb.DocDB, org string) *docDBOrchestrator {
+func newDocDBOrchestrator(client docdb.DocDB, rgclient *resourcegroupstaggingapi.ResourceGroupsTaggingAPI, org string) *docDBOrchestrator {
 	return &docDBOrchestrator{
-		client: client,
-		org:    org,
+		client:   client,
+		rgClient: rgclient,
+		org:      org,
 	}
 }

--- a/api/tags.go
+++ b/api/tags.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/docdb"
+)
+
+type Tag struct {
+	Key   string
+	Value string
+}
+
+type Tags []Tag
+
+// inOrg returns true if there is a spinup:org tag that matches our org
+func (tags *Tags) inOrg(org string) bool {
+	for _, t := range *tags {
+		if t.Key == "spinup:org" && t.Value == org {
+			return true
+		}
+	}
+	return false
+}
+
+// normalize sets required tags
+func (tags *Tags) normalize(org string) Tags {
+	normalizedTags := Tags{
+		{
+			Key:   "spinup:org",
+			Value: org,
+		},
+		{
+			Key:   "spinup:type",
+			Value: "database",
+		},
+		{
+			Key:   "spinup:flavor",
+			Value: "docdb",
+		},
+	}
+
+	for _, t := range *tags {
+		switch t.Key {
+		case "yale:org", "spinup:org", "spinup:type", "spinup:flavor":
+			continue
+		default:
+			normalizedTags = append(normalizedTags, t)
+		}
+	}
+
+	return normalizedTags
+}
+
+// toDocDBTags converts from api Tags to RDS tags
+func (tags *Tags) toDocDBTags() []*docdb.Tag {
+	docdbTags := make([]*docdb.Tag, 0, len(*tags))
+	for _, t := range *tags {
+		docdbTags = append(docdbTags, &docdb.Tag{
+			Key:   aws.String(t.Key),
+			Value: aws.String(t.Value),
+		})
+	}
+	return docdbTags
+}
+
+// fromDocDBTags converts from DocDB tags to api Tags
+func fromDocDBTags(docdbTags []*docdb.Tag) Tags {
+	tags := make(Tags, 0, len(docdbTags))
+	for _, t := range docdbTags {
+		tags = append(tags, Tag{
+			Key:   aws.StringValue(t.Key),
+			Value: aws.StringValue(t.Value),
+		})
+	}
+	return tags
+}

--- a/api/tags_test.go
+++ b/api/tags_test.go
@@ -1,0 +1,225 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_tags_inOrg(t *testing.T) {
+	type fields struct {
+		org  string
+		tags Tags
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "test matching org",
+			fields: fields{
+				org: "Metaverse",
+				tags: Tags{
+					{Key: "spinup:org", Value: "Metaverse"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "test conflicting org",
+			fields: fields{
+				org: "Metaverse",
+				tags: Tags{
+					{Key: "spinup:org", Value: "Fedland"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "test missing org",
+			fields: fields{
+				org: "Metaverse",
+				tags: Tags{
+					{Key: "CreatedBy", Value: "Hiro"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "test empty tags",
+			fields: fields{
+				org:  "Metaverse",
+				tags: nil,
+			},
+			want: false,
+		},
+		{
+			name: "test empty tags blank org",
+			fields: fields{
+				org:  "",
+				tags: nil,
+			},
+			want: false,
+		},
+		{
+			name: "test blank org match",
+			fields: fields{
+				org: "",
+				tags: Tags{
+					{Key: "spinup:org", Value: ""},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "test blank org mismatch",
+			fields: fields{
+				org: "",
+				tags: Tags{
+					{Key: "spinup:org", Value: "Fedland"},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tags := tt.fields.tags
+			got := tags.inOrg(tt.fields.org)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("tags.inOrg()\ngot:  %v\nwant: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_tags_normalize(t *testing.T) {
+	type fields struct {
+		org  string
+		tags Tags
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   Tags
+	}{
+		{
+			name: "test conflicting org",
+			fields: fields{
+				org: "testOrg",
+				tags: Tags{
+					{Key: "spinup:org", Value: "XOR"},
+				},
+			},
+			want: Tags{
+				{Key: "spinup:org", Value: "testOrg"},
+				{Key: "spinup:type", Value: "database"},
+				{Key: "spinup:flavor", Value: "docdb"},
+			},
+		},
+		{
+			name: "test conflicting type",
+			fields: fields{
+				org: "testOrg",
+				tags: Tags{
+					{Key: "spinup:type", Value: "container"},
+				},
+			},
+			want: Tags{
+				{Key: "spinup:org", Value: "testOrg"},
+				{Key: "spinup:type", Value: "database"},
+				{Key: "spinup:flavor", Value: "docdb"},
+			},
+		},
+		{
+			name: "test conflicting flavor",
+			fields: fields{
+				org: "testOrg",
+				tags: Tags{
+					{Key: "spinup:flavor", Value: "task"},
+				},
+			},
+			want: Tags{
+				{Key: "spinup:org", Value: "testOrg"},
+				{Key: "spinup:type", Value: "database"},
+				{Key: "spinup:flavor", Value: "docdb"},
+			},
+		},
+		{
+			name: "test multiple conflicting tags",
+			fields: fields{
+				org: "testOrg",
+				tags: Tags{
+					{Key: "spinup:org", Value: "XOR"},
+					{Key: "spinup:type", Value: "container"},
+					{Key: "spinup:flavor", Value: "task"},
+				},
+			},
+			want: Tags{
+				{Key: "spinup:org", Value: "testOrg"},
+				{Key: "spinup:type", Value: "database"},
+				{Key: "spinup:flavor", Value: "docdb"},
+			},
+		},
+		{
+			name: "test preserving user tags",
+			fields: fields{
+				org: "testOrg",
+				tags: Tags{
+					{Key: "CreatedBy", Value: "me"},
+					{Key: "Env", Value: "test"},
+				},
+			},
+			want: Tags{
+				{Key: "spinup:org", Value: "testOrg"},
+				{Key: "spinup:type", Value: "database"},
+				{Key: "spinup:flavor", Value: "docdb"},
+				{Key: "CreatedBy", Value: "me"},
+				{Key: "Env", Value: "test"},
+			},
+		},
+		{
+			name: "test setting org and preserving user tags",
+			fields: fields{
+				org: "testOrg",
+				tags: Tags{
+					{Key: "spinup:org", Value: "Rogue"},
+					{Key: "CreatedBy", Value: "me"},
+					{Key: "Env", Value: "test"},
+				},
+			},
+			want: Tags{
+				{Key: "spinup:org", Value: "testOrg"},
+				{Key: "spinup:type", Value: "database"},
+				{Key: "spinup:flavor", Value: "docdb"},
+				{Key: "CreatedBy", Value: "me"},
+				{Key: "Env", Value: "test"},
+			},
+		},
+		{
+			name: "test empty tags",
+			fields: fields{
+				org:  "testOrg",
+				tags: Tags{},
+			},
+			want: Tags{
+				{Key: "spinup:org", Value: "testOrg"},
+				{Key: "spinup:type", Value: "database"},
+				{Key: "spinup:flavor", Value: "docdb"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tags := tt.fields.tags
+			got := tags.normalize(tt.fields.org)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("tags.normalize()\ngot:  %v\nwant: %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/types.go
+++ b/api/types.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/docdb"
 )
 
@@ -15,7 +14,7 @@ type DocDBCreateRequest struct {
 	MasterUsername        *string
 	MasterUserPassword    *string
 	SubnetIds             []*string
-	Tags                  []*Tag
+	Tags                  Tags
 	VpcSecurityGroupIds   []*string
 }
 
@@ -24,63 +23,6 @@ type DocDBResponse struct {
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/docdb/#DBCluster
 	Cluster *docdb.DBCluster
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/docdb/#DBInstance
-	Instances []*docdb.DBInstance
-}
-
-type Tag struct {
-	Key   *string
-	Value *string
-}
-
-// normalizeTags sets required tags
-func normalizeTags(org string, tags []*Tag) []*Tag {
-	normalizedTags := []*Tag{
-		{
-			Key:   aws.String("spinup:org"),
-			Value: aws.String(org),
-		},
-		{
-			Key:   aws.String("spinup:type"),
-			Value: aws.String("database"),
-		},
-		{
-			Key:   aws.String("spinup:flavor"),
-			Value: aws.String("docdb"),
-		},
-	}
-	for _, t := range tags {
-		if aws.StringValue(t.Key) == "yale:org" ||
-			aws.StringValue(t.Key) == "spinup:org" ||
-			aws.StringValue(t.Key) == "spinup:type" ||
-			aws.StringValue(t.Key) == "spinup:flavor" {
-			continue
-		}
-		normalizedTags = append(normalizedTags, t)
-	}
-
-	return normalizedTags
-}
-
-// fromDocDBTags converts from RDS tags to api Tags
-func fromDocDBTags(ecrTags []*docdb.Tag) []*Tag {
-	tags := make([]*Tag, 0, len(ecrTags))
-	for _, t := range ecrTags {
-		tags = append(tags, &Tag{
-			Key:   t.Key,
-			Value: t.Value,
-		})
-	}
-	return tags
-}
-
-// toDocDBTags converts from api Tags to RDS tags
-func toDocDBTags(tags []*Tag) []*docdb.Tag {
-	docdbTags := make([]*docdb.Tag, 0, len(tags))
-	for _, t := range tags {
-		docdbTags = append(docdbTags, &docdb.Tag{
-			Key:   t.Key,
-			Value: t.Value,
-		})
-	}
-	return docdbTags
+	Instances []*docdb.DBInstance `json:",omitempty"`
+	Tags      Tags                `json:",omitempty"`
 }

--- a/api/types.go
+++ b/api/types.go
@@ -32,16 +32,27 @@ type Tag struct {
 	Value *string
 }
 
-// normalizeTags strips the org from the given tags and ensures it is set to the API org
+// normalizeTags sets required tags
 func normalizeTags(org string, tags []*Tag) []*Tag {
 	normalizedTags := []*Tag{
 		{
 			Key:   aws.String("spinup:org"),
 			Value: aws.String(org),
 		},
+		{
+			Key:   aws.String("spinup:type"),
+			Value: aws.String("database"),
+		},
+		{
+			Key:   aws.String("spinup:flavor"),
+			Value: aws.String("docdb"),
+		},
 	}
 	for _, t := range tags {
-		if aws.StringValue(t.Key) == "spinup:org" || aws.StringValue(t.Key) == "yale:org" {
+		if aws.StringValue(t.Key) == "yale:org" ||
+			aws.StringValue(t.Key) == "spinup:org" ||
+			aws.StringValue(t.Key) == "spinup:type" ||
+			aws.StringValue(t.Key) == "spinup:flavor" {
 			continue
 		}
 		normalizedTags = append(normalizedTags, t)

--- a/docdb/docdb.go
+++ b/docdb/docdb.go
@@ -104,8 +104,8 @@ func (d *DocDB) ListDocDBClusters(ctx context.Context) ([]string, error) {
 	return clusters, nil
 }
 
-// GetDocDB gets information on a documentDB cluster+instance
-func (d *DocDB) GetDocDB(ctx context.Context, name string) (*docdb.DBCluster, error) {
+// GetDocDBDetails gets information about a documentDB cluster
+func (d *DocDB) GetDocDBDetails(ctx context.Context, name string) (*docdb.DBCluster, error) {
 	log.Debugf("getting information about documentDB cluster %s", name)
 
 	out, err := d.Service.DescribeDBClustersWithContext(ctx, &docdb.DescribeDBClustersInput{
@@ -125,9 +125,25 @@ func (d *DocDB) GetDocDB(ctx context.Context, name string) (*docdb.DBCluster, er
 		return nil, apierror.New(apierror.ErrInternalError, msg, nil)
 	}
 
-	log.Debugf("getting documentDB cluster and instance(s) with output: %+v", out)
+	log.Debugf("getting documentDB cluster and instance(s) output: %+v", out)
 
 	return out.DBClusters[0], err
+}
+
+// GetDocDBTags gets the tags for a documentDB cluster
+func (d *DocDB) GetDocDBTags(ctx context.Context, arn *string) ([]*docdb.Tag, error) {
+	log.Debugf("getting tags for documentDB cluster %s", aws.StringValue(arn))
+
+	out, err := d.Service.ListTagsForResourceWithContext(ctx, &docdb.ListTagsForResourceInput{
+		ResourceName: arn,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debugf("getting documentDB tags output: %+v", out)
+
+	return out.TagList, err
 }
 
 // CreateDBCluster creates a documentDB cluster

--- a/docdb/docdb.go
+++ b/docdb/docdb.go
@@ -75,7 +75,7 @@ func (d *DocDB) GetDBSubnetGroup(ctx context.Context, name string) ([]*docdb.DBS
 	return out.DBSubnetGroups, nil
 }
 
-// ListDocDBs lists documentDB clusters
+// ListDocDBs lists all documentDB clusters
 func (d *DocDB) ListDocDBClusters(ctx context.Context) ([]string, error) {
 	log.Debug("listing documentDB clusters")
 

--- a/resourcegroupstaggingapi/errors.go
+++ b/resourcegroupstaggingapi/errors.go
@@ -1,0 +1,97 @@
+package resourcegroupstaggingapi
+
+import (
+	"github.com/YaleSpinup/apierror"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/pkg/errors"
+)
+
+func ErrCode(msg string, err error) error {
+	if aerr, ok := errors.Cause(err).(awserr.Error); ok {
+		switch aerr.Code() {
+		case
+
+			// ErrCodeInternalServiceException for service response error code
+			// "InternalServiceException".
+			//
+			// The request processing failed because of an unknown error, exception, or
+			// failure. You can retry the request.
+			resourcegroupstaggingapi.ErrCodeInternalServiceException:
+
+			return apierror.New(apierror.ErrInternalError, msg, err)
+		case
+
+			// ErrCodeConcurrentModificationException for service response error code
+			// "ConcurrentModificationException".
+			//
+			// The target of the operation is currently being modified by a different request.
+			// Try again later.
+			resourcegroupstaggingapi.ErrCodeConcurrentModificationException,
+
+			// ErrCodeThrottledException for service response error code
+			// "ThrottledException".
+			//
+			// The request was denied to limit the frequency of submitted requests.
+			resourcegroupstaggingapi.ErrCodeThrottledException:
+			return apierror.New(apierror.ErrConflict, msg, aerr)
+		case
+
+			// ErrCodeConstraintViolationException for service response error code
+			// "ConstraintViolationException".
+			//
+			// The request was denied because performing this operation violates a constraint.
+			//
+			// Some of the reasons in the following list might not apply to this specific
+			// operation.
+			//
+			//    * You must meet the prerequisites for using tag policies. For information,
+			//    see Prerequisites and Permissions for Using Tag Policies (http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies-prereqs.html)
+			//    in the AWS Organizations User Guide.
+			//
+			//    * You must enable the tag policies service principal (tagpolicies.tag.amazonaws.com)
+			//    to integrate with AWS Organizations For information, see EnableAWSServiceAccess
+			//    (http://docs.aws.amazon.com/organizations/latest/APIReference/API_EnableAWSServiceAccess.html).
+			//
+			//    * You must have a tag policy attached to the organization root, an OU,
+			//    or an account.
+			resourcegroupstaggingapi.ErrCodeConstraintViolationException,
+
+			// ErrCodeInvalidParameterException for service response error code
+			// "InvalidParameterException".
+			//
+			// This error indicates one of the following:
+			//
+			//    * A parameter is missing.
+			//
+			//    * A malformed string was supplied for the request parameter.
+			//
+			//    * An out-of-range value was supplied for the request parameter.
+			//
+			//    * The target ID is invalid, unsupported, or doesn't exist.
+			//
+			//    * You can't access the Amazon S3 bucket for report storage. For more information,
+			//    see Additional Requirements for Organization-wide Tag Compliance Reports
+			//    (http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies-prereqs.html#bucket-policies-org-report)
+			//    in the AWS Organizations User Guide.
+			resourcegroupstaggingapi.ErrCodeInvalidParameterException,
+
+			// ErrCodePaginationTokenExpiredException for service response error code
+			// "PaginationTokenExpiredException".
+			//
+			// A PaginationToken is valid for a maximum of 15 minutes. Your request was
+			// denied because the specified PaginationToken has expired.
+			resourcegroupstaggingapi.ErrCodePaginationTokenExpiredException:
+
+			return apierror.New(apierror.ErrBadRequest, msg, aerr)
+		case
+			"Not Found":
+			return apierror.New(apierror.ErrNotFound, msg, aerr)
+		default:
+			m := msg + ": " + aerr.Message()
+			return apierror.New(apierror.ErrBadRequest, m, aerr)
+		}
+	}
+
+	return apierror.New(apierror.ErrInternalError, msg, err)
+}

--- a/resourcegroupstaggingapi/errors_test.go
+++ b/resourcegroupstaggingapi/errors_test.go
@@ -1,0 +1,38 @@
+package resourcegroupstaggingapi
+
+import (
+	"testing"
+
+	"github.com/YaleSpinup/apierror"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/pkg/errors"
+)
+
+func TestErrCode(t *testing.T) {
+	apiErrorTestCases := map[string]string{
+		"": apierror.ErrBadRequest,
+		resourcegroupstaggingapi.ErrCodeInternalServiceException:        apierror.ErrInternalError,
+		resourcegroupstaggingapi.ErrCodeConcurrentModificationException: apierror.ErrConflict,
+		resourcegroupstaggingapi.ErrCodeThrottledException:              apierror.ErrConflict,
+		resourcegroupstaggingapi.ErrCodeConstraintViolationException:    apierror.ErrBadRequest,
+		resourcegroupstaggingapi.ErrCodeInvalidParameterException:       apierror.ErrBadRequest,
+		resourcegroupstaggingapi.ErrCodePaginationTokenExpiredException: apierror.ErrBadRequest,
+	}
+
+	for awsErr, apiErr := range apiErrorTestCases {
+		err := ErrCode("test error", awserr.New(awsErr, awsErr, nil))
+		if aerr, ok := errors.Cause(err).(apierror.Error); ok {
+			t.Logf("got apierror '%s'", aerr)
+		} else {
+			t.Errorf("expected resourcegroupstaggingapi error %s to be an apierror.Error %s, got %s", awsErr, apiErr, err)
+		}
+	}
+
+	err := ErrCode("test error", errors.New("Unknown"))
+	if aerr, ok := errors.Cause(err).(apierror.Error); ok {
+		t.Logf("got apierror '%s'", aerr)
+	} else {
+		t.Errorf("expected unknown error to be an apierror.ErrInternalError, got %s", err)
+	}
+}

--- a/resourcegroupstaggingapi/resourcegroupstaggingapi.go
+++ b/resourcegroupstaggingapi/resourcegroupstaggingapi.go
@@ -1,0 +1,120 @@
+package resourcegroupstaggingapi
+
+import (
+	"context"
+
+	"github.com/YaleSpinup/apierror"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
+	log "github.com/sirupsen/logrus"
+)
+
+// ResourceGroupsTaggingAPI is a wrapper around the aws resourcegroupstaggingapi service with some default config info
+type ResourceGroupsTaggingAPI struct {
+	session *session.Session
+	Service resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
+}
+
+type ResourceGroupsTaggingAPIOption func(*ResourceGroupsTaggingAPI)
+
+// Tag Filter is used to filter resources based on tags.  The Value portion is optional.
+type TagFilter struct {
+	Key   string
+	Value []string
+}
+
+func New(opts ...ResourceGroupsTaggingAPIOption) *ResourceGroupsTaggingAPI {
+	client := ResourceGroupsTaggingAPI{}
+
+	for _, opt := range opts {
+		opt(&client)
+	}
+
+	if client.session != nil {
+		client.Service = resourcegroupstaggingapi.New(client.session)
+	}
+
+	return &client
+}
+
+func WithSession(sess *session.Session) ResourceGroupsTaggingAPIOption {
+	return func(client *ResourceGroupsTaggingAPI) {
+		log.Debug("using aws session")
+		client.session = sess
+	}
+}
+
+func WithCredentials(key, secret, token, region string) ResourceGroupsTaggingAPIOption {
+	return func(client *ResourceGroupsTaggingAPI) {
+		log.Debugf("creating new session with key id %s in region %s", key, region)
+		sess := session.Must(session.NewSession(&aws.Config{
+			Credentials: credentials.NewStaticCredentials(key, secret, token),
+			Region:      aws.String(region),
+		}))
+		client.session = sess
+	}
+}
+
+func (r *ResourceGroupsTaggingAPI) ListResourcesWithTags(ctx context.Context, input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	if input == nil {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Info("listing tagged resources")
+
+	out, err := r.Service.GetResourcesWithContext(ctx, input)
+	if err != nil {
+		return nil, ErrCode("listing resource with tags", err)
+	}
+
+	log.Debugf("got output from get resources: %+v", out)
+
+	return out, nil
+}
+
+// GetResourcesInOrg returns all of the resources in the specified org, with a given resource type and flavor
+// More details about which services support the resourgroup tagging api here: https://docs.aws.amazon.com/ARG/latest/userguide/supported-resources.html
+func (r *ResourceGroupsTaggingAPI) GetResourcesInOrg(ctx context.Context, org, rtype, rflavor string) ([]*resourcegroupstaggingapi.ResourceTagMapping, error) {
+	if org == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("getting resources with type '%s' flavor '%s' in org %s", rtype, rflavor, org)
+
+	filters := []*resourcegroupstaggingapi.TagFilter{
+		{
+			Key:    aws.String("spinup:org"),
+			Values: []*string{aws.String(org)},
+		},
+	}
+
+	if rtype != "" {
+		filters = append(filters, &resourcegroupstaggingapi.TagFilter{
+			Key:    aws.String("spinup:type"),
+			Values: []*string{aws.String(rtype)},
+		})
+	}
+
+	if rflavor != "" {
+		filters = append(filters, &resourcegroupstaggingapi.TagFilter{
+			Key:    aws.String("spinup:flavor"),
+			Values: []*string{aws.String(rflavor)},
+		})
+	}
+
+	out, err := r.Service.GetResourcesWithContext(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+		ResourcesPerPage:    aws.Int64(100),
+		ResourceTypeFilters: aws.StringSlice([]string{"rds:cluster"}),
+		TagFilters:          filters,
+	})
+	if err != nil {
+		return nil, ErrCode("getting resources with tags", err)
+	}
+
+	log.Debugf("got output from get resources: %+v", out)
+
+	return out.ResourceTagMappingList, nil
+}

--- a/resourcegroupstaggingapi/resourcegroupstaggingapi_test.go
+++ b/resourcegroupstaggingapi/resourcegroupstaggingapi_test.go
@@ -1,0 +1,205 @@
+package resourcegroupstaggingapi
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
+)
+
+// mockResourceGroupsTaggingAPIClient is a fake resourcegroupstaggingapi client
+type mockResourceGroupsTaggingAPIClient struct {
+	resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
+	t   *testing.T
+	err error
+}
+
+func newmockResourceGroupsTaggingAPIClient(t *testing.T, err error) resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI {
+	return &mockResourceGroupsTaggingAPIClient{
+		t:   t,
+		err: err,
+	}
+}
+
+func TestNewSession(t *testing.T) {
+	client := New()
+	to := reflect.TypeOf(client).String()
+	if to != "*resourcegroupstaggingapi.ResourceGroupsTaggingAPI" {
+		t.Errorf("expected type to be '*resourcegroupstaggingapi.ResourceGroupsTaggingAPI', got %s", to)
+	}
+}
+
+type tag struct {
+	key   string
+	value string
+}
+
+type testResource struct {
+	resourceType string
+	tags         []tag
+	arn          string
+}
+
+var testResources = []testResource{
+	{
+		resourceType: "ec2:instance",
+		tags: []tag{
+			{
+				key:   "spinup:org",
+				value: "foobar",
+			},
+			{
+				key:   "spinup:spaceid",
+				value: "123",
+			},
+		},
+		arn: "arn:aws:ec2:us-east-1:1234567890:instance/i-0987654321",
+	},
+	{
+		resourceType: "elasticloadbalancing:targetgroup",
+		tags: []tag{
+			{
+				key:   "spinup:org",
+				value: "foobar",
+			},
+			{
+				key:   "spinup:spaceid",
+				value: "123",
+			},
+		},
+		arn: "arn:aws:elasticloadbalancing:us-east-1:1234567890:targetgroup/testtg123/0987654321",
+	},
+	{
+		resourceType: "elasticloadbalancing:targetgroup",
+		tags: []tag{
+			{
+				key:   "spinup:org",
+				value: "foobar",
+			},
+			{
+				key:   "spinup:spaceid",
+				value: "321",
+			},
+		},
+		arn: "arn:aws:elasticloadbalancing:us-east-1:1234567890:targetgroup/testtg321/0987654321",
+	},
+}
+
+func (m *mockResourceGroupsTaggingAPIClient) GetResourcesWithContext(ctx context.Context, input *resourcegroupstaggingapi.GetResourcesInput, opts ...request.Option) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	resourceList := []*resourcegroupstaggingapi.ResourceTagMapping{}
+	for _, r := range testResources {
+		if len(input.ResourceTypeFilters) > 0 {
+			var typeMatch bool
+			for _, t := range input.ResourceTypeFilters {
+				if aws.StringValue(t) == r.resourceType {
+					typeMatch = true
+					break
+				}
+			}
+
+			if !typeMatch {
+				continue
+			}
+		}
+
+		matches := true
+		for _, filter := range input.TagFilters {
+			innerMatch := func() bool {
+				m.t.Logf("processing tagfilter %+v", filter)
+				for _, rt := range r.tags {
+					if aws.StringValue(filter.Key) == rt.key {
+						m.t.Logf("tag keys match for %s (%s = %s)", r.arn, rt.key, aws.StringValue(filter.Key))
+						if len(filter.Values) == 0 {
+							m.t.Logf("appending %s to the list, keys match (%s = %s) and no value specified", r.arn, rt.key, aws.StringValue(filter.Key))
+							return true
+						}
+
+						for _, value := range aws.StringValueSlice(filter.Values) {
+							if value == rt.value {
+								m.t.Logf("appending %s to the list, keys match (%s = %s) and value matches (%s = %s)", r.arn, rt.key, aws.StringValue(filter.Key), value, rt.value)
+								return true
+							}
+						}
+					}
+				}
+				m.t.Logf("returning false for %s", r.arn)
+				return false
+			}()
+
+			if !innerMatch {
+				matches = false
+			}
+		}
+
+		if matches {
+			m.t.Logf("resource %s matches", r.arn)
+			resourceList = append(resourceList, &resourcegroupstaggingapi.ResourceTagMapping{
+				ResourceARN: aws.String(r.arn),
+			})
+		}
+	}
+
+	return &resourcegroupstaggingapi.GetResourcesOutput{
+		ResourceTagMappingList: resourceList,
+	}, nil
+}
+
+func TestListResourcesWithTags(t *testing.T) {
+	r := ResourceGroupsTaggingAPI{Service: newmockResourceGroupsTaggingAPIClient(t, nil)}
+	out, err := r.ListResourcesWithTags(context.TODO(), &resourcegroupstaggingapi.GetResourcesInput{
+		ResourceTypeFilters: aws.StringSlice([]string{"elasticloadbalancing:targetgroup"}),
+		TagFilters: []*resourcegroupstaggingapi.TagFilter{
+			{Key: aws.String("spinup:org"), Values: aws.StringSlice([]string{"foobar"})},
+			{Key: aws.String("spinup:spaceid"), Values: aws.StringSlice([]string{"123"})},
+		},
+	})
+
+	if err != nil {
+		t.Errorf("expected no error, got %s", err)
+	}
+
+	expected := &resourcegroupstaggingapi.GetResourcesOutput{
+		ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+			{
+				ResourceARN: aws.String("arn:aws:elasticloadbalancing:us-east-1:1234567890:targetgroup/testtg123/0987654321"),
+			},
+		},
+	}
+	if !reflect.DeepEqual(expected, out) {
+		t.Errorf("expected %+v, got %+v", expected, out)
+	}
+
+	out, err = r.ListResourcesWithTags(context.TODO(), &resourcegroupstaggingapi.GetResourcesInput{
+		TagFilters: []*resourcegroupstaggingapi.TagFilter{
+			{Key: aws.String("spinup:org"), Values: aws.StringSlice([]string{"foobar"})},
+			{Key: aws.String("spinup:spaceid"), Values: aws.StringSlice([]string{"123"})},
+		},
+	})
+
+	if err != nil {
+		t.Errorf("expected no error, got %s", err)
+	}
+
+	expected = &resourcegroupstaggingapi.GetResourcesOutput{
+		ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+			{
+				ResourceARN: aws.String("arn:aws:ec2:us-east-1:1234567890:instance/i-0987654321"),
+			},
+			{
+				ResourceARN: aws.String("arn:aws:elasticloadbalancing:us-east-1:1234567890:targetgroup/testtg123/0987654321"),
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(expected, out) {
+		t.Errorf("expected %+v, got %+v", expected, out)
+	}
+}


### PR DESCRIPTION
Before we were listing all DocDB clusters in an account, regardless of the `spinup:org`.
This change leverages `resourcegroupstaggingapi` to filter clusters based on our org tag.
It's also adding the following two special tags: `spinup:type` and `spinup:flavor`