### PR TITLE
Add support for modifying docdb parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ PUT `/v1/docdb/{account}/{name}`
 {
   "BackupRetentionPeriod": 2,
   "DBInstanceClass": "db.r5.large",
-  "MasterUserPassword": "newexamplepassword",
+  "MasterUserPassword": "newexamplepassword"
 }```
 
 | Response Code                 | Definition                      |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ GET /v1/docdb/flywheel?task=xxx[&task=yyy&task=zzz]
 POST /v1/docdb/{account}
 GET /v1/docdb/{account}
 GET /v1/docdb/{account}/{name}
+PUT /v1/docdb/{account}/{name}
 DELETE /v1/docdb/{account}/{name}?snapshot=[true|false]
 ```
 
@@ -267,6 +268,158 @@ GET `/v1/docdb/{account}/{name}`
         {
             "Key": "spinup:type",
             "Value": "database"
+        }
+    ]
+}
+```
+
+### Modify docdb cluster
+
+The modify request can be used to change the master password for the DocumentDB cluster, or other parameters, such as `BackupRetentionPeriod`, `EngineVersion` or `DBInstanceClass`
+
+PUT `/v1/docdb/{account}/{name}`
+
+```json
+{
+  "BackupRetentionPeriod": 2,
+  "DBInstanceClass": "db.r5.large",
+  "MasterUserPassword": "newexamplepassword",
+}```
+
+| Response Code                 | Definition                      |
+| ----------------------------- | --------------------------------|
+| **200 OK**                    | success modifying docdb cluster |
+| **400 Bad Request**           | badly formed request            |
+| **403 Forbidden**             | bad token or fail to assume role|
+| **404 Not Found**             | account not found               |
+| **500 Internal Server Error** | a server error occurred         |
+
+#### Example modify response
+```json
+{
+    "Cluster": {
+        "AssociatedRoles": null,
+        "AvailabilityZones": [
+            "us-east-1d",
+            "us-east-1a",
+            "us-east-1b"
+        ],
+        "BackupRetentionPeriod": 2,
+        "ClusterCreateTime": "2021-10-08T15:01:01.073Z",
+        "DBClusterArn": "arn:aws:rds:us-east-1:123456789012:cluster:mydocdb",
+        "DBClusterIdentifier": "mydocdb",
+        "DBClusterMembers": [
+            {
+                "DBClusterParameterGroupStatus": "in-sync",
+                "DBInstanceIdentifier": "mydocdb-1",
+                "IsClusterWriter": true,
+                "PromotionTier": 1
+            }
+        ],
+        "DBClusterParameterGroup": "default.docdb4.0",
+        "DBSubnetGroup": "spinup-spintg-docdb-subnetgroup",
+        "DbClusterResourceId": "cluster-QX7X4WBDAQ3S44RXW226MLMYAM",
+        "DeletionProtection": false,
+        "EarliestRestorableTime": "2021-10-08T15:01:46.142Z",
+        "EnabledCloudwatchLogsExports": null,
+        "Endpoint": "mydocdb.cluster-c9ukc6s0rmbg.us-east-1.docdb.amazonaws.com",
+        "Engine": "docdb",
+        "EngineVersion": "4.0.0",
+        "HostedZoneId": "ZNKXH85TT8WVW",
+        "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/92c75e09-8fcb-4e65-aba4-eed7f4a012f7",
+        "LatestRestorableTime": "2021-10-08T15:31:03.749Z",
+        "MasterUsername": "dadmin",
+        "MultiAZ": false,
+        "PercentProgress": null,
+        "Port": 27017,
+        "PreferredBackupWindow": "05:59-06:29",
+        "PreferredMaintenanceWindow": "tue:07:43-tue:08:13",
+        "ReadReplicaIdentifiers": null,
+        "ReaderEndpoint": "mydocdb.cluster-ro-c9ukc6s0rmbg.us-east-1.docdb.amazonaws.com",
+        "ReplicationSourceIdentifier": null,
+        "Status": "available",
+        "StorageEncrypted": true,
+        "VpcSecurityGroups": [
+            {
+                "Status": "active",
+                "VpcSecurityGroupId": "sg-0abcdef1234567890"
+            }
+        ]
+    },
+    "Instances": [
+        {
+            "AutoMinorVersionUpgrade": true,
+            "AvailabilityZone": "us-east-1a",
+            "BackupRetentionPeriod": 2,
+            "CACertificateIdentifier": "rds-ca-2019",
+            "DBClusterIdentifier": "mydocdb",
+            "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:db:mydocdb-1",
+            "DBInstanceClass": "db.r5.large",
+            "DBInstanceIdentifier": "mydocdb-1",
+            "DBInstanceStatus": "available",
+            "DBSubnetGroup": {
+                "DBSubnetGroupArn": null,
+                "DBSubnetGroupDescription": "spinup-spintg-docdb-subnetgroup",
+                "DBSubnetGroupName": "spinup-spintg-docdb-subnetgroup",
+                "SubnetGroupStatus": "Complete",
+                "Subnets": [
+                    {
+                        "SubnetAvailabilityZone": {
+                            "Name": "us-east-1d"
+                        },
+                        "SubnetIdentifier": "subnet-01234567",
+                        "SubnetStatus": "Active"
+                    },
+                    {
+                        "SubnetAvailabilityZone": {
+                            "Name": "us-east-1a"
+                        },
+                        "SubnetIdentifier": "subnet-01234568",
+                        "SubnetStatus": "Active"
+                    }
+                ],
+                "VpcId": "vpc-8bb612ec"
+            },
+            "DbiResourceId": "db-UUZG3SJ7BBBU4EJV5JW663DMIA",
+            "EnabledCloudwatchLogsExports": null,
+            "Endpoint": {
+                "Address": "mydocdb-1.c9ukc6s0rmbg.us-east-1.docdb.amazonaws.com",
+                "HostedZoneId": "ZNKXH85TT8WVW",
+                "Port": 27017
+            },
+            "Engine": "docdb",
+            "EngineVersion": "4.0.0",
+            "InstanceCreateTime": "2021-10-08T15:06:00.146Z",
+            "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/92c73e09-9fcb-4e65-aba4-eed7f4a012f7",
+            "LatestRestorableTime": null,
+            "PendingModifiedValues": {
+                "AllocatedStorage": null,
+                "BackupRetentionPeriod": null,
+                "CACertificateIdentifier": null,
+                "DBInstanceClass": null,
+                "DBInstanceIdentifier": null,
+                "DBSubnetGroupName": null,
+                "EngineVersion": null,
+                "Iops": null,
+                "LicenseModel": null,
+                "MasterUserPassword": null,
+                "MultiAZ": null,
+                "PendingCloudwatchLogsExports": null,
+                "Port": null,
+                "StorageType": null
+            },
+            "PreferredBackupWindow": "05:59-06:29",
+            "PreferredMaintenanceWindow": "mon:03:59-mon:04:29",
+            "PromotionTier": 1,
+            "PubliclyAccessible": false,
+            "StatusInfos": null,
+            "StorageEncrypted": true,
+            "VpcSecurityGroups": [
+                {
+                    "Status": "active",
+                    "VpcSecurityGroupId": "sg-0abcdef1234567890"
+                }
+            ]
         }
     ]
 }

--- a/api/orchestration.go
+++ b/api/orchestration.go
@@ -207,6 +207,7 @@ func (o *docDBOrchestrator) documentDBModify(ctx context.Context, name string, r
 
 	// modify cluster parameters
 	cluster, err := o.client.ModifyDBCluster(ctx, &docdb.ModifyDBClusterInput{
+		ApplyImmediately:       aws.Bool(true),
 		BackupRetentionPeriod:  req.BackupRetentionPeriod,
 		DBClusterIdentifier:    aws.String(name),
 		EngineVersion:          req.EngineVersion,

--- a/api/routes.go
+++ b/api/routes.go
@@ -33,5 +33,6 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}", s.DocumentDBCreateHandler).Methods(http.MethodPost)
 	api.HandleFunc("/{account}", s.DocumentDBListHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/{name}", s.DocumentDBGetHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/{name}", s.DocumentDBModifyHandler).Methods(http.MethodPut)
 	api.HandleFunc("/{account}/{name}", s.DocumentDBDeleteHandler).Methods(http.MethodDelete)
 }

--- a/api/types.go
+++ b/api/types.go
@@ -18,6 +18,17 @@ type DocDBCreateRequest struct {
 	VpcSecurityGroupIds   []*string
 }
 
+// DocDBModifyRequest is data used to modify a documentDB
+type DocDBModifyRequest struct {
+	BackupRetentionPeriod  *int64
+	DBInstanceClass        *string
+	EngineVersion          *string
+	MasterUserPassword     *string
+	NewDBClusterIdentifier *string
+	Tags                   Tags
+	VpcSecurityGroupIds    []*string
+}
+
 // DocDBResponse is the output from documentDB operations
 type DocDBResponse struct {
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/docdb/#DBCluster

--- a/docdb/docdb.go
+++ b/docdb/docdb.go
@@ -258,3 +258,39 @@ func (d *DocDB) DeleteDBInstance(ctx context.Context, input *docdb.DeleteDBInsta
 
 	return out, nil
 }
+
+// ModifyDBCluster modifies a documentDB cluster
+func (d *DocDB) ModifyDBCluster(ctx context.Context, input *docdb.ModifyDBClusterInput) (*docdb.DBCluster, error) {
+	if input == nil {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("modifying documentDB cluster: %s", aws.StringValue(input.DBClusterIdentifier))
+
+	out, err := d.Service.ModifyDBCluster(input)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debugf("modified documentDB cluster with output: %+v", out.DBCluster)
+
+	return out.DBCluster, nil
+}
+
+// ModifyDBInstance modifies a documentDB instance
+func (d *DocDB) ModifyDBInstance(ctx context.Context, input *docdb.ModifyDBInstanceInput) (*docdb.DBInstance, error) {
+	if input == nil {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("modifying documentDB instance: %s", aws.StringValue(input.DBInstanceIdentifier))
+
+	out, err := d.Service.ModifyDBInstance(input)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debugf("modified documentDB instance with output: %+v", out.DBInstance)
+
+	return out.DBInstance, nil
+}


### PR DESCRIPTION
The modify request can be used to change the master password for the DocumentDB cluster, or other parameters, such as `BackupRetentionPeriod`, `EngineVersion` or `DBInstanceClass`