### PR TITLE
Generate unique subnet group name based on subnet id's

### DIFF
--- a/api/handlers_docdb.go
+++ b/api/handlers_docdb.go
@@ -43,6 +43,16 @@ func (s *server) DocumentDBCreateHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if req.SubnetIds == nil {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "SubnetIds is a required field", nil))
+		return
+	}
+
+	if len(req.SubnetIds) < 2 {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "At least 2 SubnetIds are required", nil))
+		return
+	}
+
 	orch := newDocDBOrchestrator(
 		db.New(db.WithSession(sess.Session)),
 		nil,

--- a/api/orchestration.go
+++ b/api/orchestration.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"crypto/md5"
 	"fmt"
 	"strings"
 	"time"
@@ -10,8 +11,8 @@ import (
 	"github.com/YaleSpinup/flywheel"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/docdb"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -21,18 +22,20 @@ func (o *docDBOrchestrator) documentDBCreate(ctx context.Context, req *DocDBCrea
 
 	req.Tags = req.Tags.normalize(o.org)
 
+	sgName := dbSubnetGroupName(o.org, req.SubnetIds)
+
 	// check if a DBSubnetGroup exists, and create it if needed
-	dbSubnetGroupFound, err := o.dbSubnetGroupExists(ctx, dbSubnetGroupName(o.org))
+	dbSubnetGroupFound, err := o.dbSubnetGroupExists(ctx, sgName)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	if !dbSubnetGroupFound {
-		if err := o.dbSubnetGroupCreate(ctx, dbSubnetGroupName(o.org), req.SubnetIds); err != nil {
+		if err := o.dbSubnetGroupCreate(ctx, sgName, req.SubnetIds); err != nil {
 			return nil, nil, err
 		}
 	} else {
-		log.Infof("subnet group %s already exists, will use it for this docdb cluster", dbSubnetGroupName(o.org))
+		log.Infof("subnet group %s already exists, will use it for this docdb cluster", sgName)
 	}
 
 	task := flywheel.NewTask()
@@ -40,7 +43,7 @@ func (o *docDBOrchestrator) documentDBCreate(ctx context.Context, req *DocDBCrea
 	cluster, err := o.client.CreateDBCluster(ctx, &docdb.CreateDBClusterInput{
 		BackupRetentionPeriod: req.BackupRetentionPeriod,
 		DBClusterIdentifier:   req.DBClusterIdentifier,
-		DBSubnetGroupName:     aws.String(dbSubnetGroupName(o.org)),
+		DBSubnetGroupName:     aws.String(sgName),
 		Engine:                aws.String("docdb"),
 		EngineVersion:         req.EngineVersion,
 		MasterUsername:        req.MasterUsername,
@@ -273,17 +276,18 @@ func (o *docDBOrchestrator) documentDBDelete(ctx context.Context, name string, s
 	return nil
 }
 
-// dbSubnetGroupName determines the DBSubnetGroup based on the Org
-func dbSubnetGroupName(org string) string {
-	return fmt.Sprintf("spinup-%s-docdb-subnetgroup", org)
+// dbSubnetGroupName determines the DBSubnetGroup name based on the Org and subnet id's
+// generate a 32-char MD5 hash based on all subnet id's
+func dbSubnetGroupName(org string, subnetIds []string) string {
+	return fmt.Sprintf("spinup-%s-docdb-sg-%x", org, md5.Sum([]byte(strings.Join(subnetIds, ""))))
 }
 
 // dbSubnetGroupExists checks if a DBSubnetGroup exists
 func (o *docDBOrchestrator) dbSubnetGroupExists(ctx context.Context, name string) (bool, error) {
 	result, err := o.client.GetDBSubnetGroup(ctx, name)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			if aerr.Code() == docdb.ErrCodeDBSubnetGroupNotFoundFault {
+		if aerr, ok := errors.Cause(err).(apierror.Error); ok {
+			if aerr.Code == apierror.ErrNotFound {
 				log.Debugf("subnet group not found: %s", name)
 				return false, nil
 			} else {
@@ -295,22 +299,22 @@ func (o *docDBOrchestrator) dbSubnetGroupExists(ctx context.Context, name string
 	if len(result) == 1 {
 		return true, nil
 	} else {
-		return false, apierror.New(apierror.ErrInternalError, "unexpected number of matching subnet groups", nil)
+		return false, apierror.New(apierror.ErrInternalError, "unexpected number of matching subnet groups: "+fmt.Sprint(len(result)), nil)
 	}
 }
 
 // dbSubnetGroupCreate creates a DBSubnetGroup
-func (o *docDBOrchestrator) dbSubnetGroupCreate(ctx context.Context, name string, subnets []*string) error {
+func (o *docDBOrchestrator) dbSubnetGroupCreate(ctx context.Context, name string, subnets []string) error {
 	if subnets == nil {
 		return apierror.New(apierror.ErrBadRequest, "no subnets specified", nil)
 	}
 
-	log.Infof("creating DBSubnetGroup %s with subnets: %v", name, aws.StringValueSlice(subnets))
+	log.Infof("creating DBSubnetGroup %s with subnets: %v", name, subnets)
 
 	_, err := o.client.CreateDBSubnetGroup(ctx, &docdb.CreateDBSubnetGroupInput{
 		DBSubnetGroupDescription: aws.String(name),
 		DBSubnetGroupName:        aws.String(name),
-		SubnetIds:                subnets,
+		SubnetIds:                aws.StringSlice(subnets),
 	})
 	if err != nil {
 		return apierror.New(apierror.ErrBadRequest, "failed to create DBSubnetGroup", err)

--- a/api/orchestration.go
+++ b/api/orchestration.go
@@ -87,7 +87,7 @@ func (o *docDBOrchestrator) documentDBCreate(ctx context.Context, req *DocDBCrea
 
 		msgChan <- fmt.Sprintf("requested creation of docdb cluster %s", cl)
 
-		if err = retry(10, 2*time.Second, func() error {
+		if err = retry(10, 3, 10*time.Second, func() error {
 			msgChan <- fmt.Sprintf("checking if docdb cluster %s is available before continuing", cl)
 
 			// check cluster status

--- a/api/server.go
+++ b/api/server.go
@@ -203,10 +203,9 @@ func retry(attempts int, doubling int, sleep time.Duration, f func() error) erro
 			time.Sleep(sleep)
 			if doubling--; doubling > 0 {
 				return retry(attempts, doubling, 2*sleep, f)
-			} else {
-				// stop doubling the sleep interval after some point to prevent it from getting too big
-				return retry(attempts, doubling, sleep, f)
 			}
+			// stop doubling the sleep interval after some point to prevent it from getting too big
+			return retry(attempts, 0, sleep, f)
 		}
 		return err
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -184,21 +184,29 @@ type stop struct {
 	error
 }
 
-// retry is stolen from https://upgear.io/blog/simple-golang-retry-function/
-func retry(attempts int, sleep time.Duration, f func() error) error {
+// retry was originally borrowed from https://upgear.io/blog/simple-golang-retry-function/
+// it will retry the given code _f_ for the specified number of _attempts_
+// sleeping after each attempt, starting with _sleep_ time and doubling it
+// for the first _doubling_ times, then keeping it constant (+ jitter)
+func retry(attempts int, doubling int, sleep time.Duration, f func() error) error {
 	if err := f(); err != nil {
 		if s, ok := err.(stop); ok {
-			// Return the original error for later checking
+			// return the original error for later checking
 			return s.error
 		}
 
 		if attempts--; attempts > 0 {
-			// Add some randomness to prevent creating a Thundering Herd
+			// add some randomness to prevent creating a Thundering Herd
 			jitter := time.Duration(rand.Int63n(int64(sleep)))
 			sleep = sleep + jitter/2
 
 			time.Sleep(sleep)
-			return retry(attempts, 2*sleep, f)
+			if doubling--; doubling > 0 {
+				return retry(attempts, doubling, 2*sleep, f)
+			} else {
+				// stop doubling the sleep interval after some point to prevent it from getting too big
+				return retry(attempts, doubling, sleep, f)
+			}
 		}
 		return err
 	}

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -53,13 +53,13 @@ func TestRollback(t *testing.T) {
 }
 
 func TestRetry(t *testing.T) {
-	if err := retry(3, 1*time.Millisecond, func() error {
+	if err := retry(3, 2, 1*time.Millisecond, func() error {
 		return errors.New("boom")
 	}); err == nil {
 		t.Error("expected error when exceeding retry attempts, got nil")
 	}
 
-	if err := retry(3, 1*time.Millisecond, func() error {
+	if err := retry(3, 2, 1*time.Millisecond, func() error {
 		return nil
 	}); err != nil {
 		t.Errorf("unexpected error for successful retry, got %s", err)
@@ -75,7 +75,7 @@ func TestRetry(t *testing.T) {
 		return fmt.Errorf("too small %d", tr)
 	}
 
-	if err := retry(3, 1*time.Millisecond, f); err != nil {
+	if err := retry(3, 2, 1*time.Millisecond, f); err != nil {
 		t.Errorf("unexpected error for successful retry, got %s", err)
 	}
 }

--- a/api/types.go
+++ b/api/types.go
@@ -13,7 +13,7 @@ type DocDBCreateRequest struct {
 	EngineVersion         *string
 	MasterUsername        *string
 	MasterUserPassword    *string
-	SubnetIds             []*string
+	SubnetIds             []string
 	Tags                  Tags
 	VpcSecurityGroupIds   []*string
 }

--- a/docdb/errors.go
+++ b/docdb/errors.go
@@ -155,6 +155,13 @@ func ErrCode(msg string, err error) error {
 			// DBClusterIdentifier doesn't refer to an existing cluster.
 			docdb.ErrCodeDBClusterNotFoundFault,
 
+			// ErrCodeDBClusterParameterGroupNotFoundFault for service response error code
+			// "DBClusterParameterGroupNotFound".
+			//
+			// DBClusterParameterGroupName doesn't refer to an existing cluster parameter
+			// group.
+			docdb.ErrCodeDBClusterParameterGroupNotFoundFault,
+
 			// ErrCodeDBClusterSnapshotNotFoundFault for service response error code
 			// "DBClusterSnapshotNotFoundFault".
 			//
@@ -167,11 +174,29 @@ func ErrCode(msg string, err error) error {
 			// DBInstanceIdentifier doesn't refer to an existing instance.
 			docdb.ErrCodeDBInstanceNotFoundFault,
 
+			// ErrCodeDBParameterGroupNotFoundFault for service response error code
+			// "DBParameterGroupNotFound".
+			//
+			// DBParameterGroupName doesn't refer to an existing parameter group.
+			docdb.ErrCodeDBParameterGroupNotFoundFault,
+
+			// ErrCodeDBSecurityGroupNotFoundFault for service response error code
+			// "DBSecurityGroupNotFound".
+			//
+			// DBSecurityGroupName doesn't refer to an existing security group.
+			docdb.ErrCodeDBSecurityGroupNotFoundFault,
+
 			// ErrCodeDBSnapshotNotFoundFault for service response error code
 			// "DBSnapshotNotFound".
 			//
 			// DBSnapshotIdentifier doesn't refer to an existing snapshot.
 			docdb.ErrCodeDBSnapshotNotFoundFault,
+
+			// ErrCodeDBSubnetGroupNotFoundFault for service response error code
+			// "DBSubnetGroupNotFoundFault".
+			//
+			// DBSubnetGroupName doesn't refer to an existing subnet group.
+			docdb.ErrCodeDBSubnetGroupNotFoundFault,
 
 			// ErrCodeGlobalClusterNotFoundFault for service response error code
 			// "GlobalClusterNotFoundFault".

--- a/docdb/errors_test.go
+++ b/docdb/errors_test.go
@@ -36,14 +36,14 @@ func TestErrCode(t *testing.T) {
 		docdb.ErrCodeDBUpgradeDependencyFailureFault:     apierror.ErrConflict,
 
 		docdb.ErrCodeAuthorizationNotFoundFault:         apierror.ErrBadRequest,
-		docdb.ErrCodeDBSecurityGroupNotFoundFault:       apierror.ErrBadRequest,
 		docdb.ErrCodeDBSubnetGroupDoesNotCoverEnoughAZs: apierror.ErrBadRequest,
-		docdb.ErrCodeDBSubnetGroupNotFoundFault:         apierror.ErrBadRequest,
 
 		docdb.ErrCodeDBClusterNotFoundFault:         apierror.ErrNotFound,
 		docdb.ErrCodeDBClusterSnapshotNotFoundFault: apierror.ErrNotFound,
 		docdb.ErrCodeDBInstanceNotFoundFault:        apierror.ErrNotFound,
 		docdb.ErrCodeDBSnapshotNotFoundFault:        apierror.ErrNotFound,
+		docdb.ErrCodeDBSecurityGroupNotFoundFault:   apierror.ErrNotFound,
+		docdb.ErrCodeDBSubnetGroupNotFoundFault:     apierror.ErrNotFound,
 		docdb.ErrCodeGlobalClusterNotFoundFault:     apierror.ErrNotFound,
 		docdb.ErrCodeResourceNotFoundFault:          apierror.ErrNotFound,
 


### PR DESCRIPTION
Unfortunately, single subnet is not allowed in the subnet groups, DocumentDB requires at least 2 AZs :(

Also tweaked the `retry` func to prevent unlimited retry interval doubling.